### PR TITLE
add ability to install on Magento 2.3.x via composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "AFL-3.0"
     ],
     "description":"Magento2 extension for Cookie SameSite attribute.",
-    "version":"2.3.0",
+    "version":"2.3.1",
     "authors":[
         {
             "name":"Hirokazu Nishi",
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "~7.2.0||~7.3.0||~7.4.0",
-        "magento/framework": "~102.0.5||~103.0.0",
+        "magento/framework": "~102.0.0||~103.0.0",
         "lib-libxml": "*"
     },
     "autoload": {


### PR DESCRIPTION
Currently it is not possible to install module on Magento v2.3.2 via composer due to this requirement 
``` 
"magento/framework": "~102.0.5"
```
Module has been tested on v2.3.2, so I assume this requirement can be updated.
Thanks