### PR TITLE
Add mandatory 'secure' to cookie when forcing 'SameSite=None'

### DIFF
--- a/Plugin/Session/AddSameSite.php
+++ b/Plugin/Session/AddSameSite.php
@@ -49,6 +49,8 @@ class AddSameSite
             return $result;
         }
 
+        $subject->setOption('session.cookie_secure', 1);
+
         if ($version >= 70300) {
             $subject->setOption('session.cookie_samesite', 'None');
         } else {

--- a/Stdlib/Cookie/CookieManager.php
+++ b/Stdlib/Cookie/CookieManager.php
@@ -174,7 +174,10 @@ class CookieManager implements CookieManagerInterface
             if (array_key_exists(ExtendPulicCookieMetadata::KEY_SAMESITE, $metadataArray)) {
                 $options = array_merge($options, [self::KEY_SAME_SITE => $metadataArray[ExtendPulicCookieMetadata::KEY_SAMESITE]]);
             } elseif ($sameSite) {
-                $options = array_merge($options, [self::KEY_SAME_SITE => 'None']);
+                $options = array_merge($options, [
+                    self::KEY_SAME_SITE => 'None',
+                    self::KEY_SECURE => true
+                ]);
             }
 
             $phpSetcookieSuccess = setcookie(

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": "~7.2.0||~7.3.0||~7.4.0",
-        "magento/framework": "~102.0.0||~103.0.0",
         "lib-libxml": "*"
     },
     "autoload": {


### PR DESCRIPTION
This fix is required, else on Chrome (85) you get the following error:

![image](https://user-images.githubusercontent.com/2028709/96377413-95d3a280-11c0-11eb-979c-0917f09e840f.png)
