### PR TITLE
Implement return type and parameter type on the Rewrite file

### DIFF
--- a/Rewrite/Stdlib/Cookie/PublicCookieMetadata.php
+++ b/Rewrite/Stdlib/Cookie/PublicCookieMetadata.php
@@ -2,6 +2,7 @@
 declare(strict_types = 1);
 namespace Veriteworks\CookieFix\Rewrite\Stdlib\Cookie;
 
+use Magento\Framework\Stdlib\Cookie\CookieMetadata;
 use Magento\Framework\Stdlib\Cookie\PublicCookieMetadata as Base;
 
 /**
@@ -15,9 +16,9 @@ class PublicCookieMetadata extends Base
      * Set SameSite flag
      *
      * @param string $sameSite
-     * @return \Magento\Framework\Stdlib\Cookie\PublicCookieMetadata
+     * @return CookieMetadata
      */
-    public function setSameSite($sameSite)
+    public function setSameSite(string $sameSite): CookieMetadata
     {
         return $this->set(self::KEY_SAMESITE, $sameSite);
     }


### PR DESCRIPTION
In this case, when implementing this extension on the latest magento version 2.3.6-p1 and with PHP 7.3 the rewrite function does return the CookieMetadata as the parent function does: vendor/magento/framework/Stdlib/Cookie/CookieMetadata.php:157

In this commit the correct parameter type is added as well as the correct return type

Ideally this needs to be a new bump from 2.3.1 to 2.3.2

Please edit my target branch if it's incorrect.