### PR TITLE
Unsecure cookie fix

### DIFF
--- a/Plugin/Session/ModifySameSite.php
+++ b/Plugin/Session/ModifySameSite.php
@@ -52,6 +52,10 @@ class ModifySameSite
      */
     public function beforeSetCookieSameSite(ConfigInterface $subject, string $cookieSameSite = 'Lax'): array
     {
+        if (!$subject->getCookieSecure()) {
+            return [$cookieSameSite];
+        }
+        
         $agent = $this->header->getHttpUserAgent();
         $sameSite = $this->validator->shouldSendSameSiteNone($agent);
         if ($sameSite === false) {


### PR DESCRIPTION
[\Magento\Framework\Session\Config::setCookieSameSite
](https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/Session/Config.php#L591)

```
public function setCookieSameSite(string $cookieSameSite = 'Lax'): ConfigInterface
{
    $validator = $this->_validatorFactory->create(
        [],
        CookieSameSiteValidator::class
    );
    if (!$validator->isValid($cookieSameSite) ||
        **!$this->getCookieSecure() && strtolower($cookieSameSite) === 'none'**) {
        throw new \InvalidArgumentException(
            'Invalid Samesite attribute.'
        );
    }
    $this->setOption('session.cookie_samesite', $cookieSameSite);
    return $this;
}
```

You can't make samesite None if cookie is unsecure